### PR TITLE
大佬，发现您的项目引入了com.google.guava:guava@28.1-jre组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.hyp.learn</groupId>
@@ -12,7 +10,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
+            <version>30.0-android</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Google Guava访问控制错误漏洞
缺陷组件：com.google.guava:guava@28.1-jre
漏洞编号：CVE-2020-8908
漏洞描述：Google Guava是美国谷歌（Google）公司的一款包括图形库、函数类型、I/O和字符串处理等的Java核心库。
Guava 30.0版本之前存在访问控制错误漏洞，该漏洞源于Guava存在一个临时目录创建漏洞，允许访问机器的攻击者可利用该漏洞潜在地访问由Guava com.google.common.io.Files.createTempDir()创建的临时目录中的数据。攻击者可以利用该漏洞访问特殊目录。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2021-31252
影响范围：(∞, 30.0-android)
最小修复版本：30.0-android
缺陷组件引入路径：com.hyp.learn:LeedCodeLearn@1.0-SNAPSHOT->com.google.guava:guava@28.1-jre
```
另外我运行这个项目时，IDE的安全插件提示还有几个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p4e861